### PR TITLE
operations interfaces

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 plugins {
     kotlin("jvm")
     jacoco
@@ -5,7 +9,9 @@ plugins {
     `maven-publish`
 
 }
+
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,7 +23,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.7")
+    compile("io.titandata:remote-sdk:0.0.10")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
 }
 

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
 }
 

--- a/client/src/main/kotlin/io/titandata/remote/nop/client/NopRemoteClient.kt
+++ b/client/src/main/kotlin/io/titandata/remote/nop/client/NopRemoteClient.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.nop.client
 
 import io.titandata.remote.RemoteClient

--- a/client/src/test/kotlin/io/titandata/remote/nop/client/NopRemoteClientTest.kt
+++ b/client/src/test/kotlin/io/titandata/remote/nop/client/NopRemoteClientTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.nop.client
 
 import io.kotlintest.shouldBe

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 plugins {
     kotlin("jvm")
     jacoco
@@ -6,6 +10,7 @@ plugins {
 
 }
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,7 +22,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.7")
+    compile("io.titandata:remote-sdk:0.0.10")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")
 }

--- a/server/src/main/kotlin/io/titandata/remote/nop/server/NopRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/nop/server/NopRemoteServer.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.nop.server
 
 import io.titandata.remote.RemoteOperation
@@ -70,15 +74,15 @@ class NopRemoteServer : RemoteServer {
         }
     }
 
-    /**
-     * There is nothing to do for nop operations
-     */
     override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
+        // Nothing to do
     }
 
-    /**
-     * There is nothing to do for nop operations
-     */
     override fun syncVolume(operation: RemoteOperation, volumeName: String, volumeDescription: String, volumePath: String, scratchPath: String) {
+        // Nothing to do
+    }
+
+    override fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean) {
+        // Nothing to do
     }
 }

--- a/server/src/test/kotlin/io/titandata/remote/nop/server/NopRemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/nop/server/NopRemoteServerTest.kt
@@ -20,6 +20,7 @@ class NopRemoteServerTest : StringSpec() {
     private val op = RemoteOperation(
             operationId = "op",
             commitId = "commit",
+            commit = null,
             remote = emptyMap(),
             parameters = emptyMap(),
             type = RemoteOperationType.PUSH,

--- a/server/src/test/kotlin/io/titandata/remote/nop/server/NopRemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/nop/server/NopRemoteServerTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.nop.server
 
 import io.kotlintest.TestCase
@@ -81,6 +85,10 @@ class NopRemoteServerTest : StringSpec() {
 
         "start operation succeeds" {
             client.startOperation(op)
+        }
+
+        "push metadata does nothing" {
+            client.pushMetadata(op, emptyMap(), true)
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

This adds all the interfaces required by the new remote SDK. While I was here, I also cleaned up some copyright stuff and made it so you could link to libraries in your local maven repository.

## Testing

`gradle build`. Also ran all tests in `titan-server` with new remote.