### PR TITLE
update to stable version of remote-sdk

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.11")
+    compile("io.titandata:remote-sdk:0.1.0")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
 }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.11")
+    compile("io.titandata:remote-sdk:0.1.0")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")
 }


### PR DESCRIPTION
## Proposed Changes

Updates to use remote-sdk version 0.1.0, which is functionally identical but published through official releases.

## Testing

`gradle build`